### PR TITLE
Add hpool.hpp to `hpool` target to appear in Visual Studio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 add_library(hpool INTERFACE)
 add_library(hpool::hpool ALIAS hpool)
+target_sources(hpool INTERFACE hpool.hpp)
 target_include_directories(hpool INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(tests test/tests.cpp)


### PR DESCRIPTION
Visual Studio does not show header files unless explicitly mentioned.